### PR TITLE
Fix invalid HTML

### DIFF
--- a/site/public/index.html
+++ b/site/public/index.html
@@ -35,18 +35,24 @@
 			<div class="inner">
 				<ul class="header-links-list">
 					<li class="header-links-label">Follow our progress:</li>
-					<li><a href="https://twitter.com/touchstonejs">
-						<i class="ion-social-twitter"></i>
-						<span class="header-link">Twitter</span>
-					</li></a>
-					<li><a href="https://github.com/jedwatson/touchstonejs" target="_blank">
-						<i class="ion-social-github"></i>
-						<span class="header-link">Github</span>
-					</li></a>
-					<li><a href="http://demo.touchstonejs.io" target="_blank">
-						<i class="ion-monitor"></i>
-						<span class="header-link">Demo</span>
-					</li></a>
+					<li>
+						<a href="https://twitter.com/touchstonejs">
+							<i class="ion-social-twitter"></i>
+							<span class="header-link">Twitter</span>
+						</a>
+					</li>
+					<li>
+						<a href="https://github.com/jedwatson/touchstonejs" target="_blank">
+							<i class="ion-social-github"></i>
+							<span class="header-link">Github</span>
+						</a>
+					</li>
+					<li>
+						<a href="http://demo.touchstonejs.io" target="_blank">
+							<i class="ion-monitor"></i>
+							<span class="header-link">Demo</span>
+						</a>
+					</li>
 			</div>
 		</div>
 	</header>


### PR DESCRIPTION
Fixes an issue where `li` tag was closed before `a` tag. Also separated the lines for better visibility of these types of issues. 
