### PR TITLE
Removed not used proptypes and added nametag to UI.LabelTextArea

### DIFF
--- a/lib/ui/LabelTextarea.js
+++ b/lib/ui/LabelTextarea.js
@@ -1,34 +1,39 @@
-var React = require('react/addons'),
-	classnames = require('classnames');
+var React = require('react/addons');
+var	classnames = require('classnames');
+var _ = require('underscore');
 
 module.exports = React.createClass({
 	displayName: 'LabelTextarea',
-	propTypes: {
-		className: React.PropTypes.string,
-		onChange: React.PropTypes.func,
-		label: React.PropTypes.string,
-		first: React.PropTypes.bool,
-		name: React.PropTypes.string
-	},
 	getDefaultProps: function() {
 		return {
-			className: '',
 			rows: 3
 		};
 	},
 	render: function() {
+		var disabled = this.props.disabled || this.props.readonly;
 		var className = classnames(this.props.className, {
 			'list-item': true,
 			'field-item': true,
 			'align-top': true,
 			'is-first': this.props.first,
-			'u-selectable': this.props.disabled || this.props.readonly
+			'u-selectable': disabled
 		});
+
+		// FIXME: we can do better
+		var curated = _.extend({
+			ref: this.props.inputRef
+		}, this.props);
+		delete curated.className;
+		delete curated.disabled;
+		delete curated.first;
+		delete curated.readonly;
+		delete curated.children;
+		delete curated.inputRef;
 
 		var renderInput = this.props.readonly ? (
 			<div className="field u-selectable">{this.props.value}</div>
 		) : (
-			<textarea disabled={this.props.disabled} value={this.props.value} defaultValue={this.props.defaultValue} onChange={this.props.onChange} placeholder={this.props.placeholder} rows={this.props.rows} name={this.props.name} className="field" />
+			<textarea disabled={disabled} {...curated} className="field" />
 		);
 
 		return (

--- a/lib/ui/LabelTextarea.js
+++ b/lib/ui/LabelTextarea.js
@@ -6,10 +6,9 @@ module.exports = React.createClass({
 	propTypes: {
 		className: React.PropTypes.string,
 		onChange: React.PropTypes.func,
-		type: React.PropTypes.string,
 		label: React.PropTypes.string,
-		noedit: React.PropTypes.bool,
-		first: React.PropTypes.bool
+		first: React.PropTypes.bool,
+		name: React.PropTypes.string
 	},
 	getDefaultProps: function() {
 		return {
@@ -29,7 +28,7 @@ module.exports = React.createClass({
 		var renderInput = this.props.readonly ? (
 			<div className="field u-selectable">{this.props.value}</div>
 		) : (
-			<textarea disabled={this.props.disabled} value={this.props.value} defaultValue={this.props.defaultValue} onChange={this.props.onChange} placeholder={this.props.placeholder} rows={this.props.rows} className="field" />
+			<textarea disabled={this.props.disabled} value={this.props.value} defaultValue={this.props.defaultValue} onChange={this.props.onChange} placeholder={this.props.placeholder} rows={this.props.rows} name={this.props.name} className="field" />
 		);
 
 		return (

--- a/lib/ui/LabelTextarea.js
+++ b/lib/ui/LabelTextarea.js
@@ -20,15 +20,13 @@ module.exports = React.createClass({
 		});
 
 		// FIXME: we can do better
-		var curated = _.extend({
-			ref: this.props.inputRef
-		}, this.props);
+		var curated = _.extend({}, this.props);
 		delete curated.className;
 		delete curated.disabled;
 		delete curated.first;
 		delete curated.readonly;
 		delete curated.children;
-		delete curated.inputRef;
+		delete curated.label;
 
 		var renderInput = this.props.readonly ? (
 			<div className="field u-selectable">{this.props.value}</div>


### PR DESCRIPTION
I wanted to use UI.LabelTextArea with react-form-data, but that needs that all input fields have names. That possibility was not added to UI.LabelTextArea.

Alternative solution would also be to pass all attributes on UI.LabelTextArea to the textarea itself via spread.

Any preferences?

PS: I also removed not used proptypes.