### PR TITLE
Headerbar-label container not rendered when no label is provided

### DIFF
--- a/lib/ui/Headerbar.js
+++ b/lib/ui/Headerbar.js
@@ -24,6 +24,6 @@ module.exports = React.createClass({
 				{this.props.children}
 				{label}
 			</FlexBlock>
-		)
+		);
 	}
 });

--- a/lib/ui/Headerbar.js
+++ b/lib/ui/Headerbar.js
@@ -16,12 +16,14 @@ module.exports = React.createClass({
 			'Headerbar': true,
 			'fixed': this.props.fixed
 		}, this.props.className, this.props.type);
+		
+		var label = (this.props.label) ? <div className="Headerbar-label">{this.props.label}</div> : null;
 
 		return (
 			<FlexBlock height={this.props.height} className={className}>
 				{this.props.children}
-				<div className="Headerbar-label">{this.props.label}</div>
+				{label}
 			</FlexBlock>
-		);
+		)
 	}
 });


### PR DESCRIPTION
I had the issue that using the example of the Toggle, that the label container is then overlapping my content area and prevents in the toparea clicks from being recognized. Therefore I have made the label container dependent on the existance of the label.