### PR TITLE
Update to react 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,10 @@
     "tween.js": "^16.3.4"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
-    "react-container": "^0.3.1",
-    "react-tappable": "^0.7.1",
-    "react-addons-css-transition-group": "^0.14.0"
+     "react": "^15.1.0",
+     "react-dom": "^15.1.0",
+     "react-tappable": "^0.8.1",
+     "react-addons-css-transition-group": "^15.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.4.5",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "gulp-less": "^3.0.5",
     "gutil": "^1.6.4",
     "happiness": "^1.0.7",
-    "react-router": "^0.13.3",
+    "react-router": "^2.5.2",
     "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
I have been using touchstonejs with react 15 for some time with no issues, but it would be nice to not have to use my own fork to do so.

This should also close #119 
